### PR TITLE
Check if logged in

### DIFF
--- a/git-p4
+++ b/git-p4
@@ -1541,6 +1541,10 @@ class P4Sync(Command):
             print "Finding files belonging to labels in %s" % `self.depotPaths`
 
         for output in l:
+            if output['code'] == 'error':
+                sys.stderr.write("p4 returned an error: %s\n"
+                                 % output['data'])
+                sys.exit(1)
             label = output["label"]
             revisions = {}
             newestChange = 0


### PR DESCRIPTION
git-p4 currently errors if you are not logged in because it doesn't
check for an error code in the query in it makes. It now checks and
will exit accordingly.
