### PR TITLE
Fix for p4 branches with silly characters in them

### DIFF
--- a/git-p4
+++ b/git-p4
@@ -1579,7 +1579,7 @@ class P4Sync(Command):
         lostAndFoundBranches = set()
 
         for info in self.p4.p4CmdList("branches"):
-            details = self.p4.p4Cmd("branch -o %s" % info["branch"])
+            details = self.p4.p4Cmd("branch -o \"%s\"" % info["branch"])
             viewIdx = 0
             while details.has_key("View%s" % viewIdx):
                 paths = details["View%s" % viewIdx].split(" ")


### PR DESCRIPTION
For some reason somebody thought it was a good idea to create branches containing ">" characters.  It might be possible to include quote characters in branch names or other similar madness, this fixes my immediate issue though.
