### PR TITLE
Hi, I'm just trying to use git-p4 now and was getting usage errors due to using the git-p4.host setting. This sets "-h host" on the p4 cmdline, but the correct option (for my version of p4 at least) is -H. If this is a bug, I guess most people are just us

### DIFF
--- a/git-p4
+++ b/git-p4
@@ -79,7 +79,7 @@ class P4Helper:
 
         host = gitConfig("git-p4.host")
         if len(host) > 0:
-            real_cmd += "-h %s " % host
+            real_cmd += "-H %s " % host
 
         client = gitConfig("git-p4.client")
         if len(client) > 0:


### PR DESCRIPTION
Use the '-H' on the p4 cmdline option for host, not -h, as per usage:

```
    -H host         set host name (default $P4HOST)
```
