### PR TITLE
add --dry-run option to 'p4 submit'

### DIFF
--- a/git-p4
+++ b/git-p4
@@ -811,6 +811,7 @@ class P4Submit(Command):
         Command.__init__(self)
         self.options = [
                 optparse.make_option("--verbose", dest="verbose", action="store_true"),
+                optparse.make_option("--dry-run", dest="dryRun", action="store_true"),
                 optparse.make_option("--origin", dest="origin"),
                 optparse.make_option("--auto", dest="interactive", action="store_false", help="Automatically submit changelists without requiring editing"),
                 optparse.make_option("-M", dest="detectRename", action="store_true", help="detect renames"),
@@ -829,6 +830,7 @@ class P4Submit(Command):
         if gitConfig("git-p4.detectCopy") == "true":
             self.detectCopy = True
         self.verbose = False
+        self.dryRun = False
         self.isWindows = (platform.system() == "Windows")
         self.importIntoRemotes = True
         if gitConfig("git-p4.importIntoRemotes") == "false":
@@ -1158,6 +1160,12 @@ class P4Submit(Command):
 
         if self.verbose:
             print "Commits to apply: %s" % self.commits
+
+        if self.dryRun:
+            print "Would submit"
+            for commit in self.commits:
+                print (read_pipe("git log --max-count=1 --pretty=oneline %s" % commit))
+            return True
 
         self.applyCommits()
         

--- a/git-p4
+++ b/git-p4
@@ -812,6 +812,7 @@ class P4Submit(Command):
         self.options = [
                 optparse.make_option("--verbose", dest="verbose", action="store_true"),
                 optparse.make_option("--dry-run", dest="dryRun", action="store_true"),
+                optparse.make_option("--no-squash", dest="noSquash", action="store_true"),
                 optparse.make_option("--origin", dest="origin"),
                 optparse.make_option("--auto", dest="interactive", action="store_false", help="Automatically submit changelists without requiring editing"),
                 optparse.make_option("-M", dest="detectRename", action="store_true", help="detect renames"),
@@ -831,6 +832,7 @@ class P4Submit(Command):
             self.detectCopy = True
         self.verbose = False
         self.dryRun = False
+        self.noSquash = False
         self.isWindows = (platform.system() == "Windows")
         self.importIntoRemotes = True
         if gitConfig("git-p4.importIntoRemotes") == "false":
@@ -1154,7 +1156,8 @@ class P4Submit(Command):
         self.check()
 
         self.commits = []
-        for line in read_pipe_lines("git rev-list --no-merges %s..%s" % (self.origin, self.master)):
+        revListOption = "--no-merges" if self.noSquash else "--first-parent"
+        for line in read_pipe_lines("git rev-list %s %s..%s" % (revListOption, self.origin, self.master)):
             self.commits.append(line.strip())
         self.commits.reverse()
 


### PR DESCRIPTION
This commit adds an option so that you can see which git commits you would send to p4 before you do so, something I find very useful.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ermshiperete/git-p4/20)

<!-- Reviewable:end -->
