### PR TITLE
Fix p4 submit losing changelists.

### DIFF
--- a/git-p4
+++ b/git-p4
@@ -1091,11 +1091,6 @@ class P4Submit(Command):
         diff = "\n".join( read_pipe_lines("git diff \"%s^\" \"%s\"" % (id, id)) )
         template = self.prepareSubmitTemplate()
         changelist = self.submit(template, logMessage, diff)
-        
-        # Add note
-        if changelist > 0:
-            cmd = 'git notes --ref=git-p4 add -m "[depot-paths = \\"%s\\": change = %s]" %s' % (self.depotPath, changelist, id)
-            system(cmd)
 
     def applyCommits(self):
         while len(self.commits) > 0 and self.abort == False:
@@ -1162,8 +1157,6 @@ class P4Submit(Command):
         self.applyCommits()
         
         if self.abort == False:
-            system("git update-ref %s%s %s" % (getRefsPrefix(self.importIntoRemotes), self.master, self.master))
-
             if len(self.commits) == 0:
                 print "All changes applied!"
                 chdir(self.oldWorkingDirectory)


### PR DESCRIPTION
'git p4 submit' was updating the p4/master ref and the git-p4 notes
after a successful submission. As a result any changes between the last
'git p4 sync' and 'git p4 submit' would not get sync'd upon future 'git
p4 syncs' because git-p4 would think that the local repository was
sync'd up to the submitted revision. This change does not update the
local repository and instead forces you to 'git p4 sync' to sync your
new changes from the p4 depot.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ermshiperete/git-p4/21)

<!-- Reviewable:end -->
