### PR TITLE
Fix up temporary file usage for Windows

### DIFF
--- a/git-p4
+++ b/git-p4
@@ -780,10 +780,11 @@ class P4FileReader:
 
             if header['type'].startswith('utf16'):
                 # Don't even try to convert utf16. Ask p4 to write the file directly.
-                tmpFile = tempfile.NamedTemporaryFile()
-                P4Helper().p4_system("print -o \"%s\" \"%s\"" % (tmpFile.name, escapeStringP4(header['depotFile'])))
-                text = open(tmpFile.name).read()
-                tmpFile.close()
+                with tempfile.NamedTemporaryFile(delete=False) as tmpFile:
+                    tmpFileName = tmpFile.name
+                P4Helper().p4_system("print -o \"%s\" \"%s\"" % (tmpFileName, escapeStringP4(header['depotFile'])))
+                print "done"
+                text = open(tmpFileName).read()
             else:
                 text = textBuffer.getvalue()
             textBuffer.close()


### PR DESCRIPTION
On Windows you can't overwrite a file that you're holding an open file
handle for. Create a temporary file with delete=false and reuse the
filename instead. (This is less than ideal, but at least makes git-p4 work
on Windows.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ermshiperete/git-p4/24)
<!-- Reviewable:end -->
